### PR TITLE
Fixed install message with PATH instead of actual path, opta.sh location, version

### DIFF
--- a/content/en/Installation/_index.md
+++ b/content/en/Installation/_index.md
@@ -43,9 +43,9 @@ versions of all of Opta's dependencies are invoked when run.
 
 ```bash
 # Download the script and add it as an executable on your machine
-sudo curl https://raw.githubusercontent.com/run-x/opta-docs/opta-via-docker/static/opta.sh -o /usr/local/bin/opta.sh
-chmod +x /usr/local/bin/opta.sh
-./opta.sh # This first invocation builds a docker image
+sudo curl  https://docs.opta.dev/opta.sh -o /usr/local/bin/opta.sh
+sudo chmod +x /usr/local/bin/opta.sh
+opta.sh # This first invocation builds a docker image
 ```
 
 Invoke opta using opta.sh instead; for example

--- a/static/install.sh
+++ b/static/install.sh
@@ -118,7 +118,7 @@ if ln -fs ~/.opta/opta /usr/local/bin/opta ; then
 else
   echo "Please symlink the opta binary to one of your path directories; for example using 'sudo ln -fs ~/.opta/opta /usr/local/bin/opta'"
   echo "Alternatively, you could add the .opta installation directory to your path like so"
-  echo "export PATH=$PATH:"$RUNPATH""
+  echo "export PATH=\$PATH:"$RUNPATH
   echo "to your terminal profile."
 fi
 

--- a/static/opta.sh
+++ b/static/opta.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OPTAVERSION=0.19.0
+OPTAVERSION=0.22.0
 
 # Architecture check
 ARCH=""
@@ -104,7 +104,7 @@ cat << EOF > /tmp/opta/Dockerfile
 # base image
 FROM python:3.8.12-bullseye
 RUN apt-get update
-
+RUN echo "Going to build opta v$OPTAVERSION"
 # aws cli
 RUN apt install unzip curl groff less -y
 RUN curl "$AWSCLI2URL" -o "awscliv2.zip"


### PR DESCRIPTION
1. Fixed url for opta.sh
2. Fixed PATH suggestion at the end of the install.sh script  to not print entire path but only $PATH
3. Fixed docker install sudo issue
4. Fixed docker install version change issue - so image rebuilds if the optaversion has changed in opta.sh
