### PR TITLE
Batch of small documentation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 resources/
 node_modules/
 tech-doc-hugo
-
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 
 ## Traditional
 
-- Fetch git submodules: `git submodule update --init --recursive`
-- Install hugo: `brew install hugo`
-- Install npm dependancies: `npm install`
-- Run hugo server: `hugo server`
+1. Fetch git submodules: `git submodule update --init --recursive`
+1. Install hugo: `brew install hugo`
+1. Install npm dependancies: `npm install`
+1. Run hugo server: `hugo server`
 
 ## Docker-compose
 
-Install docker-compose and
-```bash
-docker-compose up
-```
+1. Fetch git submodules: `git submodule update --init --recursive`
+1. Install docker-compose and
+    ```bash
+    docker-compose up
+    ```
 
 You can now see the site at http://localhost:1313 Any changes you make will get instantly updated in the browser!
 

--- a/content/en/Architecture/aws.md
+++ b/content/en/Architecture/aws.md
@@ -46,7 +46,7 @@ Lastly, DNS and SSL are currently handled via one Route53 hosted zone and one AC
 verification is done with Route53 record manipulation in the given hosted zone. Records will be added to the hosted
 zone directing to the load balancer via an open source integration (see K8s section).
 
-### Security Concerns
+### Security Overview
 
 - With linkerd and domain delegation complete, Opta environments will have end-to-end encryption on all Opta services.
 - All databases and ec2s are run within the private subnets (i.e. can access the internet via a nat gateway, but
@@ -68,5 +68,3 @@ zone directing to the load balancer via an open source integration (see K8s sect
 - 5 day backup retentions for the postgres/documentdb databases.
 - Currently, the EKS cluster is built with a public endpoint for the simple usage (can add private option later on once
   VPN feature is added).
-
-For specific compliance concerns

--- a/content/en/Architecture/aws.md
+++ b/content/en/Architecture/aws.md
@@ -10,7 +10,10 @@ description: >
 
 ## AWS
 
-![image alt text](/images/opta_aws_architecture.png)
+<a href="/images/opta_aws_architecture.png" target="_blank">
+  <img src="/images/opta_aws_architecture.png" align="center"/>
+</a>
+
 For AWS our environments are currently setup within a single region, but our networking is set up across 3 availability
 zones by default, split between a private and public subnet (which we provision as we do not use the default vpc).
 The public subnet is solely used for the public load balancer, while the ec2s (VMs) and databases all exist within

--- a/content/en/Architecture/azure.md
+++ b/content/en/Architecture/azure.md
@@ -10,7 +10,10 @@ description: >
 
 ## Azure
 
-![image alt text](/images/opta_azure_architecture.png)
+<a href="/images/opta_azure_architecture.png" target="_blank">
+  <img src="/images/opta_azure_architecture.png" align="center"/>
+</a>
+
 For Azure, our environments are currently setup within a single region/subnet which azure can automatically distribute
 between all the region's availability zones. The subnet is a private one and only the load balancer and Azure storage
 are allowed to be reachable from the public internet (although the Azure storage would typically require credentials).

--- a/content/en/Architecture/azure.md
+++ b/content/en/Architecture/azure.md
@@ -37,7 +37,7 @@ Lastly, Opta does not handle DNS or SSL in Azure due to complexities of Azure. O
 [own ssl certificate into our system](/miscellaneous/ingress) to get SSL. Once your DNS zone points to the IP address of the load balancer
 provisioned by Opta your application will be live and protected by SSL.
 
-### Security Concerns
+### Security Overview
 
 - With linkerd and domain delegation complete, Opta environments will have end-to-end encryption on all Opta services.
 - All vms are run within the private subnet (i.e. can access the internet via a nat gateway, but

--- a/content/en/Architecture/gcp.md
+++ b/content/en/Architecture/gcp.md
@@ -39,7 +39,7 @@ Lastly, DNS and SSL are currently handled via one Cloud DNS hosted zone and one 
 respectively. SSL cert verification is done automatically by GCP by manipulating existing resources. Records will be
 added to the hosted zone directing to the load balancer via an open source integration (see K8s section).
 
-### Security Concerns
+### Security Overview
 
 - With linkerd and domain delegation complete, Opta environments will have end-to-end encryption on all Opta services.
 - All vms are run within the private subnet (i.e. can access the internet via a nat gateway, but

--- a/content/en/Architecture/gcp.md
+++ b/content/en/Architecture/gcp.md
@@ -10,7 +10,10 @@ description: >
 
 ## GCP
 
-![image alt text](/images/opta_gcp_architecture.png)
+<a href="/images/opta_gcp_architecture.png" target="_blank">
+  <img src="/images/opta_gcp_architecture.png" align="center"/>
+</a>
+
 For GCP our environments are currently setup within a single region/subnet which google can automatically distribute
 between all the region's availability zones. The subnet is a private one and only the load balancer and GCS buckets
 are allowed to be reachable from the public internet (although the GCS buckets would typically require credentials).

--- a/content/en/Architecture/kubernetes.md
+++ b/content/en/Architecture/kubernetes.md
@@ -63,7 +63,7 @@ one Opta service will not be able to manipulate the K8s resources for another. T
 used for sensitive custom data, as well as database access credentials. Lastly, we have a configmap (for EKS) which
 currently holds the latest public key needed for documentdb usage.
 
-### Security Concerns
+### Security Overview
 
 - [Here is Linkerd's security audit](https://github.com/linkerd/linkerd2/blob/main/SECURITY_AUDIT.pdf)
 - All cross-service communication is encrypted via mTLS

--- a/content/en/Architecture/kubernetes.md
+++ b/content/en/Architecture/kubernetes.md
@@ -10,7 +10,9 @@ description: >
 
 ## K8s
 
-![image alt text](/images/opta_internal_kubernetes_architecture.png)
+<a href="/images/opta_internal_kubernetes_architecture.png" target="_blank">
+  <img src="/images/opta_internal_kubernetes_architecture.png" align="center"/>
+</a>
 
 The K8s topology is divided into namespaces of 2 types: 3rd party integrations and Opta services. The third party
 integrations consist of respected open source projects which handle background tasks or features expansions. These

--- a/content/en/Compliance/_index.md
+++ b/content/en/Compliance/_index.md
@@ -100,7 +100,7 @@ GCP infrastructure is near-SOC2 and PCI compliant. This lack of coverage is due 
 2. The Vms of the GKE nodegroups do not have their disks encrypted by a KMS key. The reason for this is that this 
    feature is still in beta, at least in the terraform specs. We will update this as soon as it becomes GA.
 
-These are important security concerns which the opta team will keep an eye out until a feasible solution is found.
+These are important Security Overview which the opta team will keep an eye out until a feasible solution is found.
 Furthermore, the following default settings will have to be modified:
 
 

--- a/content/en/Getting started/aws.md
+++ b/content/en/Getting started/aws.md
@@ -47,11 +47,14 @@ Now, run:
 opta apply -c staging.yml
 ```
 
-This step will create an EKS cluster for you and set up VPC, networking and various other infrastructure pieces.
+For the first run, this step takes approximately 15 min.  
+It will create an EKS cluster and set up the VPC, networking and various other infrastructure pieces.  
+For more information about what is created, see [AWS Architecture](/architecture/aws/).
+
 
 ## Service creation
 
-In this step we will create a service - which is basically a docker container and associated database.
+In this step we will create a service - which is basically a docker container.
 In this example we are using the popular [httbin](https://httpbin.org/) container as our application.
 
 

--- a/content/en/Getting started/azure.md
+++ b/content/en/Getting started/azure.md
@@ -16,7 +16,7 @@ One line installation ([detailed instructions](/installation)):
 /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
 ```
 
-Make sure the Azure cloud credentails are configured in your terminal.
+Make sure the Azure cloud credentials are configured in your terminal.
 
 ## Environment creation
 
@@ -48,11 +48,13 @@ Now, run:
 opta apply -c staging.yaml
 ```
 
-This step will create an AKS cluster for you and set up networking and various other infrastructure pieces.
+For the first run, this step takes approximately 15 min.  
+It will create an AKS cluster and set up the networking and various other infrastructure pieces.  
+For more information about what is created, see [Azure Architecture](/architecture/azure/).
 
 ## Service creation
 
-In this step we will create a service - which is basically a docker container and associated database.
+In this step we will create a service - which is basically a docker container.
 In this example we are using the popular [httbin](https://httpbin.org/) container as our application.
 
 

--- a/content/en/Getting started/gcp.md
+++ b/content/en/Getting started/gcp.md
@@ -45,11 +45,14 @@ Now, run:
 opta apply -c staging.yml
 ```
 
-This step will create an GKE cluster for you and set up networking and various other infrastructure pieces.
+For the first run, this step takes approximately 15 min.  
+It will create an GKE cluster and set up the networking and various other infrastructure pieces.  
+For more information about what is created, see [GCP Architecture](/architecture/gcp/).
+
 
 ## Service creation
 
-In this step we will create a service - which is basically a docker container and associated database.
+In this step we will create a service - which is basically a docker container.
 In this example we are using the popular [httbin](https://httpbin.org/) container as our application.
 
 

--- a/content/en/Installation/_index.md
+++ b/content/en/Installation/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Installation"
+title: "Installation and Upgrade"
 linkTitle: "Installation"
 weight: 3
 ---
@@ -20,7 +20,7 @@ Opta currently has the following system prerequisites to operate normally:
 
 ## MacOS or Linux
 
-Run this script to install the latest version of Opta (see below for changelog
+Run this script to install or upgrade to the latest version of Opta (see below for changelog
 and release history).
 
 ```bash
@@ -37,7 +37,7 @@ VERSION=0.x /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
 
 We are now offering a pre-release version for running opta via a docker container with alpha support. __Please do not use this for production workloads currently.__
 
-If you prefer to install Opta and its dependencies (terraform, kubectl, gcp sdk, aws cli) in a docker container then you can 
+If you prefer to install or upgrade Opta and its dependencies (terraform, kubectl, gcp sdk, aws cli) in a docker container then you can 
 download the `opta.sh` script that runs Opta inside a docker container. With this approach you can be assured that the correct
 versions of all of Opta's dependencies are invoked when run.
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -16,6 +16,16 @@ instead of getting lost in low level cloud configuration. Imagine just being abl
 an autoscaling docker container that talks to a RDS database - instead of figuring out the details of VPC,
 IAM, Kubernetes, Elastic Load Balancing etc -- that's what Opta does!
 
+<p align="center">
+  <iframe src="https://www.youtube.com/embed/nja_EfpGexE" 
+      width="560" 
+      height="315"
+      frameborder="0" 
+      margin: 0 auto;
+      allowfullscreen>
+  </iframe>
+</p>
+
 ## Who is it for?
 
 Opta is designed for folks who are not Infrastructure or Devops experts but still want to build amazing,
@@ -23,13 +33,6 @@ scalable, secure Infra in the cloud. Majority of Opta's users are early stage st
 dev/staging/production environments.
 
 If you'd like to try it out or have any questions - feel free to join our [Slack](https://slack.opta.dev/)!
-
-<p align="center">
-  <a href="https://www.youtube.com/watch?v=nja_EfpGexE"><img src="https://img.youtube.com/vi/nja_EfpGexE/0.jpg"></a>
-  </br>
-  <span><i>Demo Video</i></span>
-  
-</p>
 
 ## What you get with Opta
 

--- a/content/en/tutorials/cron.md
+++ b/content/en/tutorials/cron.md
@@ -10,13 +10,14 @@ description: >
 With Opta, you can easily create cron jobs - jobs that run on a schedule.
 To create a job, you need to add the following module to your yaml file:
 
-```
+```yaml
 name: hello
 environments:
   - name: # env name
     path: # path to env file
 modules:
   - type: helm-chart
+    # see https://github.com/ameijer/k8s-as-helm for reference
     repository: https://ameijer.github.io/k8s-as-helm/
     chart: cronjob
     chart_version: 1.0.0

--- a/content/en/tutorials/debugging.md
+++ b/content/en/tutorials/debugging.md
@@ -48,7 +48,7 @@ Before you can use `kubectl`, you need to connect it to your kubernetes cluster
 (created by opta). This is pretty simple in the Opta world! Just run:
 
 ```
-  Opta configure-kubectl
+opta configure-kubectl
 ```
 
 ### View pods

--- a/content/en/tutorials/environment_variables.md
+++ b/content/en/tutorials/environment_variables.md
@@ -26,7 +26,8 @@ modules:
     healthcheck_path: ...
     public_uri: ...
     env_vars:
-      API_KEY: "value"
+      - name: "API_KEY"
+        value: "value"
 ```
 
 With this configuration, your container will get an env var named `API_KEY` with
@@ -34,8 +35,6 @@ the value `value`!
 
 You can also use Opta's interpolation features to refer to other values:
 
-- "{layer_name}" refers to the current yml file's name
-- "{parent_name}" refers to the parent file's name
-- "{variables}" refers to [templatization variables](/tutorials/templatization)
+- "{variables}" refers to [templatization variables](/tutorials/templatization_variables)
 - "{parent.output}" where `output` is the name of one of parent module's outputs
   (consult the module reference for output names)

--- a/content/en/tutorials/iam.md
+++ b/content/en/tutorials/iam.md
@@ -11,8 +11,8 @@ description: >
 Identity access management, IAM, is how a user can control permissions to read and/or modify resources in their
 cloud accounts. When Opta runs, it uses your currently configured credentials for your role/user of your cloud provider
 to read your state, and update/create resources as needed. Due to the large amount and variety of resources opta
-is responsible for, we recommend folks to use a role/user with account admin privileges for Opta, but we hope to
-begin providing more specific policies in the future. Furthermore, the k8s cluster needs authentication and
+is responsible for, we recommend folks to use a role/user with account admin privileges for Opta, but we have plans to
+provide more specific policies in the future. Furthermore, the k8s cluster needs authentication and
 authorization to read and write resources to itself, which is tied to the cloud provider's IAM. Below, we go over the
 specifics for the setup for each cloud.
 

--- a/content/en/tutorials/secrets.md
+++ b/content/en/tutorials/secrets.md
@@ -37,7 +37,7 @@ modules:
 2. Update secret
 
 ```bash
-opta secret update MY_SECRET_1 <value>
+opta secret update MY_SECRET_1 "value"
 ```
 
 3. List all secrets

--- a/content/en/tutorials/templatization_variables.md
+++ b/content/en/tutorials/templatization_variables.md
@@ -1,6 +1,6 @@
 ---
-title: "Templatization"
-linkTitle: "Templatization"
+title: "Templatization Variables"
+linkTitle: "Templatization Variables"
 date: 2021-07-21
 draft: false
 description: >


### PR DESCRIPTION
In Getting started aws and gcp, 
- Include a brief summary of what is created and a link to the AWS Architecture page (or the relevant cloud provider architecture document)
- Give a time estimate in the tutorial about opta apply commands (15 min for cloud, 5 min for local)

In cron jobs documentation, The repository values returns 404 https://ameijer.github.io/k8s-as-helm/ (because it’s a helm chart), 
- post a link to the github repo as a comment so the user can see what is this repo

In Configure kubectl
- typo Opta -> opta

In Environment Variables documentation
- Remove the layer and parent variables, they are a bit confusing right now. Once we have peer file relationship (RUNX-1013), we should review variables from one module can be referenced.
- rewrite the env variables document to use the name/value syntax for better compatibility with k8s manifest files

In IAM Guidance documentation
- reference future roadmap in the section about specific policies

In installation documentation
- Update the install section to mention that the same command is used of install and upgrade

In secrets documentation
- use double quote for the value definition, it works better with special characters (<, space…) opta secret update MY_SECRET_1 "value"

In templatization documentation
- use a more descriptive tile such as “Environment specific variables”

In AWS/GCP/Azure Architecture documentation
- Rename to Security Overview. And do the same of other cloud providers.
- Make the diagrams bigger and clicking on them will show the image full screen

In homepage
- embed the youtube video

In readme:
- update docker-compose instructions