### PR TITLE
Fix azure example

### DIFF
--- a/content/en/Getting started/azure.md
+++ b/content/en/Getting started/azure.md
@@ -41,6 +41,7 @@ providers:
 modules:
   - type: base
   - type: k8s-cluster
+    admin_group_object_ids: []
   - type: k8s-base
 ```
 


### PR DESCRIPTION
fix this error:
```
Opta file validation failed with errors:
  : modules.1: admin_group_object_ids: Required field missing
ERROR: env-azure.yaml is not a valid Opta file.
```
Note: this is a workaround until we fix opta to not require this field.