### PR TITLE
Document opta secret bulk-secrets

### DIFF
--- a/content/en/tutorials/secrets.md
+++ b/content/en/tutorials/secrets.md
@@ -1,7 +1,7 @@
 ---
 title: "Secrets"
 linkTitle: "Secrets"
-date: 2022-01-03
+date: 2022-01-19
 description: >
   Creating secrets for your application
 ---
@@ -9,16 +9,11 @@ description: >
 Opta provides built-in secret management for your applications. Any secrets like database passwords, api keys, should not be written in the code (including opta.yaml) because if the code is leaked accidentally, your infrastructure is exposed to hackers.
 
 Opta enables you to store these in an encrypted fashion inside the kubernetes
-cluster. To use the secrets functionality:
+cluster. To use the secrets functionality use the `opta secret` command.
 
-- Define the secrets in the service's opta file
-- Use the `opta secret` cli to update the values
-- With the next `opta deploy`, these secrets will be visible to your container
-  as environment variables.
+For this example, we can reuse the service defined in the [Getting Started](/getting-started/) guide.
 
-1. Define secrets in the service file:
-
-{{< highlight yaml "hl_lines=11-13" >}}
+```yaml
 # hello.yaml
 name: hello
 environments:
@@ -30,34 +25,86 @@ modules:
     port:
       http: 80
     image: ghcr.io/run-x/opta-examples/hello-app:main
-    secrets:
-      - MY_SECRET_1
-      - MY_SECRET_2
-{{< / highlight >}}
+    healthcheck_path: "/"
+    public_uri: "/hello"
 
-
-
-2. Update a secret
-
-```bash
-opta secret update MY_SECRET_1 "value"
-
-Success
 ```
 
-3. List all secrets
 
-```bash
-opta secret list
+1. Create or update a secret with the `secret update` command
 
-MY_SECRET_1
-MY_SECRET_2
-```
+    ```bash
+    opta secret update -c hello.yaml MY_SECRET_1 "value_1"
+    ```
+    ```
+    Success
+    ```
 
-4. View a secret value
+1. Or if you want to create multiple secrets, use the `secret bulk-update` command
 
-```bash
-opta secret view MY_SECRET_1
+    ```
+    # example of .env file containing secrets
+    cat secrets.env 
+    MY_SECRET_2=value_2
+    MY_SECRET_3=value_3
+    ```
+    ```bash
+    opta secret bulk-update -c hello.yaml secrets.env
+    ```
+    ```
+    Success
+    ```
 
-value
-```
+1. List all secrets with the `secret list` command
+
+    ```bash
+    opta secret list -c hello.yaml
+    ```
+    ```console
+    MY_SECRET_1=value_1
+    MY_SECRET_2=value_2
+    MY_SECRET_3=value_3
+    ```
+
+1. View a secret value with the `secret view` command
+
+    ```bash
+    opta secret view -c hello.yaml MY_SECRET_1
+    ```
+    ```
+    value_1
+    ```
+
+2. If you the service to access the secrets at runtime, add them to the service opta file.
+
+    ```yaml
+    name: hello
+    environments:
+      - name: staging
+        path: "opta.yaml"
+    modules:
+      - type: k8s-service
+        name: hello
+        port:
+          http: 80
+        image: ghcr.io/run-x/opta-examples/hello-app:main
+        # add this section below
+        secrets:
+          - MY_SECRET_1
+          - MY_SECRET_2
+          - MY_SECRET_3
+    ```
+
+    ```bash
+    # apply the changes to have the secrets defined as environment variables
+    opta apply -c hello.yaml
+    ```
+
+    ```bash
+    # test that the secrets are available at runtime
+    opta shell -c hello.yaml
+    env | grep MY_SECRET_
+    MY_SECRET_1=value_1
+    MY_SECRET_2=value_2
+    MY_SECRET_3=value_3
+    ```


### PR DESCRIPTION
- `opta secret bulk-secrets` to update secrets using a .env file
- `opta secret list` prints in the .env format
- `opta apply` does not check for all secrets to exist before applying

related to https://github.com/run-x/opta/pull/587