### PR TITLE
Bumped up logdna version, 

### DIFF
--- a/content/en/observability/logdna.md
+++ b/content/en/observability/logdna.md
@@ -25,7 +25,7 @@ modules:
   - type: helm-chart # <-- Add this for LogDNA support
     chart: agent
     repository: https://assets.logdna.com/charts
-    chart_version: 203.1.0
+    chart_version: 203.3.2
     values:
       logdna:
         key: <your ingestion key>


### PR DESCRIPTION
While the current chart version in the docs also works with 1.22, its at least 10 releases behind, so upgrading chart version.

Tested with k8s 1.18 and 1.22 as working