### PR TITLE
Suppress symbolic link error

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -184,7 +184,6 @@ if [[ "$GIT_EMAIL" == "" ]]; then
 fi
 
 echo "Downloading installation package..."
-echo $PACKAGE
 curl -s -L $PACKAGE -o /tmp/opta.zip --fail
 if [[ $? != 0 ]]; then
   echo "Version $VERSION not found."

--- a/static/install.sh
+++ b/static/install.sh
@@ -184,6 +184,7 @@ if [[ "$GIT_EMAIL" == "" ]]; then
 fi
 
 echo "Downloading installation package..."
+echo $PACKAGE
 curl -s -L $PACKAGE -o /tmp/opta.zip --fail
 if [[ $? != 0 ]]; then
   echo "Version $VERSION not found."
@@ -216,10 +217,10 @@ chmod u+x ~/.opta/opta
 
 RUNPATH=~/.opta
 # Add symlink if possible, or tell the user to use sudo for symlinking
-if ln -fs ~/.opta/opta /usr/local/bin/opta ; then
+if ln -fs ~/.opta/opta /usr/local/bin/opta 2>/dev/null ; then
   echo "Opta symlinked to /usr/local/bin/opta; You can now type 'opta' in the terminal to run it."
 else
-  echo "Please symlink the opta binary to one of your path directories; for example using 'sudo ln -fs ~/.opta/opta /usr/local/bin/opta'"
+  echo "Please symlink the opta binary to one of your path directories; for example using 'sudo ln -fs $RUNPATH/opta /usr/local/bin/opta'"
   echo "Alternatively, you could add the .opta installation directory to your path like so"
   echo "export PATH=\$PATH:"$RUNPATH
   echo "to your terminal profile."


### PR DESCRIPTION
Suppress the Symbolic link error which comes up due to permissions lacking.

```bash
ubuntu@ip-172-26-8-235:~/repos/opta-docs$ ./static/install.sh
Welcome to the opta installer.
Checking Prerequisites...
Determining latest version
Going to install opta v0.27.2
Downloading installation package...
https://dev-runx-opta-binaries.s3.amazonaws.com/linux/0.27.2/opta.zip
Downloaded
Opta already installed. Overwrite? y
Installing...
Please symlink the opta binary to one of your path directories; for example using 'sudo ln -fs /home/ubuntu/.opta/opta /usr/local/bin/opta'
Alternatively, you could add the .opta installation directory to your path like so
export PATH=$PATH:/home/ubuntu/.opta
to your terminal profile.
```