### PR TITLE
remove quotes

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -54,7 +54,7 @@ compare_version() {
     return 0
   fi
   local IFS=.
-  local i ver1=("$1") ver2=("$2")
+  local i ver1=($1) ver2=($2)
   # fill empty fields in ver1 with zeros
   for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do
     ver1[i]=0


### PR DESCRIPTION
Installation script was giving errors because of adding quotes, which made an array work as a string.
This was affecting the `compare_version` functionality