### PR TITLE
fix module name of k8s-manifest

### DIFF
--- a/content/en/Reference/aws/modules/k8s-manifest.md
+++ b/content/en/Reference/aws/modules/k8s-manifest.md
@@ -1,6 +1,6 @@
 ---
-title: "kubernetes-manifest"
-linkTitle: "kubernetes-manifest"
+title: "k8s-manifest"
+linkTitle: "k8s-manifest"
 date: 2022-01-11
 draft: false
 weight: 1

--- a/content/en/Reference/azurerm/modules/k8s-manifest.md
+++ b/content/en/Reference/azurerm/modules/k8s-manifest.md
@@ -1,6 +1,6 @@
 ---
-title: "kubernetes-manifest"
-linkTitle: "kubernetes-manifest"
+title: "k8s-manifest"
+linkTitle: "k8s-manifest"
 date: 2022-01-11
 draft: false
 weight: 1

--- a/content/en/Reference/google/modules/k8s-manifest.md
+++ b/content/en/Reference/google/modules/k8s-manifest.md
@@ -1,6 +1,6 @@
 ---
-title: "kubernetes-manifest"
-linkTitle: "kubernetes-manifest"
+title: "k8s-manifest"
+linkTitle: "k8s-manifest"
 date: 2022-01-11
 draft: false
 weight: 1


### PR DESCRIPTION
When using `kubernetes-manifest` as per the docs, we get an error upon `generate-terraform`

```
ERROR: kubernetes-manifest is not a valid module type
If you need more help please reach out to the contributors in our slack channel at: https://slack.opta.dev/
Checking for version upgrades...
User on the latest version.
```

Checking the source:
https://github.com/run-x/opta/tree/cfd4ddd81a47320df33ca15fc0f4814c79836f38/modules/k8s_manifest

The module is called `k8s-manifest`, not `kubernetes-manifest`

With `k8s-manifest` the module is found (although there is currently another bug in the module itself). 